### PR TITLE
Adding action text to projects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'redis', '~> 4.0'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 gem 'dotenv-rails', groups: [:development, :test]
 gem 'cloudinary', '~> 1.16.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,9 @@ GEM
       domain_name (~> 0.5)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.11.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     listen (3.2.1)
@@ -126,6 +129,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
     mimemagic (0.3.5)
+    mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
@@ -203,6 +207,8 @@ GEM
     rexml (3.2.4)
     ruby-graphviz (1.2.5)
       rexml
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -277,6 +283,7 @@ DEPENDENCIES
   dotenv-rails
   faker
   font-awesome-sass
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -1,0 +1,36 @@
+//
+// Provides a drop-in pointer for the default Trix stylesheet that will format the toolbar and
+// the trix-editor content (whether displayed or under editing). Feel free to incorporate this
+// inclusion directly in any other asset bundle and remove this file.
+//
+//= require trix/dist/trix
+
+// We need to override trix.css’s image gallery styles to accommodate the
+// <action-text-attachment> element we wrap around attachments. Otherwise,
+// images in galleries will be squished by the max-width: 33%; rule.
+.trix-content {
+  .attachment-gallery {
+    > action-text-attachment,
+    > .attachment {
+      flex: 1 0 33%;
+      padding: 0 0.5em;
+      max-width: 33%;
+    }
+
+    &.attachment-gallery--2,
+    &.attachment-gallery--4 {
+      > action-text-attachment,
+      > .attachment {
+        flex-basis: 50%;
+        max-width: 50%;
+      }
+    }
+  }
+
+  action-text-attachment {
+    .attachment {
+      padding: 0 !important;
+      max-width: 100% !important;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,8 @@
 @import "bootstrap/scss/bootstrap";
 @import "font-awesome-sprockets";
 @import "font-awesome";
+@import "./actiontext.scss";
+@import "trix/dist/trix";
 
 // Your CSS partials
 @import "components/index";

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -61,6 +61,6 @@ class ProjectsController < ApplicationController
   end
 
   def strong_params
-    params.require(:project).permit(:title, :description, :difficulty, :duration, technology_ids: [] )
+    params.require(:project).permit(:title, :description, :rich_content, :difficulty, :duration, technology_ids: [] )
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -61,6 +61,6 @@ class ProjectsController < ApplicationController
   end
 
   def strong_params
-    params.require(:project).permit(:title, :description, :rich_content, :difficulty, :duration, technology_ids: [] )
+    params.require(:project).permit(:title, :description, :rich_content, :document, :difficulty, :duration, technology_ids: [] )
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,7 +8,6 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 
-
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
 // or the `imagePath` JavaScript helper below.
@@ -24,6 +23,8 @@ require("channels")
 
 // External imports
 import "bootstrap";
+require("trix")
+require("@rails/actiontext")
 
 // Internal imports, e.g:
 // import { initSelect2 } from '../components/init_select2';
@@ -59,5 +60,6 @@ document.addEventListener('turbolinks:load', () => {
 });
 
 import { tns } from "../../../node_modules/tiny-slider/src/tiny-slider"
+
 
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,6 +8,7 @@ class Project < ApplicationRecord
   has_many :project_technologies, dependent: :destroy
   has_many :technologies, through: :project_technologies
   has_rich_text :rich_content
+  has_one_attached :document
   validates :title, :description, :duration, :difficulty, presence: true
   validates :title, length: { in: 10..200 }
   validates :description, length: { in: 20..1500 }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,6 +7,7 @@ class Project < ApplicationRecord
   has_many :messages, through: :chatroom
   has_many :project_technologies, dependent: :destroy
   has_many :technologies, through: :project_technologies
+  has_rich_text :rich_content
   validates :title, :description, :duration, :difficulty, presence: true
   validates :title, length: { in: 10..200 }
   validates :description, length: { in: 20..1500 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,9 +13,6 @@ class User < ApplicationRecord
   validates :first_name, :last_name, presence:true
   validates :first_name, :last_name, length: { minimum: 2 }
   has_one_attached :photo
-  # Level
-  LEVELS = %w(beginner intermediate advanced)
-  validates :expertise_level, inclusion: { in: LEVELS }
 
   include PgSearch::Model
   pg_search_scope :search_by_name_address_and_technologies,

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,0 +1,14 @@
+<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+  <% if blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% end %>
+
+  <figcaption class="attachment__caption">
+    <% if caption = blob.try(:caption) %>
+      <%= caption %>
+    <% else %>
+      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+    <% end %>
+  </figcaption>
+</figure>

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,7 +1,6 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
   <% if blob.representable? %>
     <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
-  <% end %>
 
   <figcaption class="attachment__caption">
     <% if caption = blob.try(:caption) %>
@@ -11,4 +10,9 @@
       <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
     <% end %>
   </figcaption>
+  <% else %>
+    <%= link_to blob.filename, rails_blob_path(blob) %>
+  <% end %>
 </figure>
+
+

--- a/app/views/components/_form_project.html.erb
+++ b/app/views/components/_form_project.html.erb
@@ -10,6 +10,8 @@
         <%= simple_form_for @project do |f| %>
           <%= f.input :title, placeholder: "i.e Blog with Ruby on Rails" %>
           <%= f.input :description, input_html: { rows: 5, cols: 40 }, placeholder: "Include main technologies and app functionality..." %>
+          <%= f.label "Project resources" %>
+          <%= f.rich_text_area :rich_content %>
           <div class="row">
             <div class="col">
                <%= f.input :duration, label: "Duration (in days)" %>

--- a/app/views/components/_form_user.html.erb
+++ b/app/views/components/_form_user.html.erb
@@ -6,7 +6,6 @@
         <%= simple_form_for @user do |f| %>
           <%= f.input :first_name, placeholder: @user.first_name %>
           <%= f.input :last_name, placeholder: @user.first_name %>
-          <%= f.input :expertise_level, collection: User::LEVELS %>
           <%= f.input :photo, as: :file %>
           <%= f.input :personal_summary, input_html: { rows: 5, cols: 40 }, placeholder: "Include you background main technologies..." %>
           <div class="row">
@@ -14,7 +13,7 @@
                <%= f.input :address, label: "Address" %>
             </div>
             <div class="col">
-              <%= f.input :expertise_level, collection: User::LEVELS %>
+              <%= f.input :expertise_level, collection: %w(beginner intermediate advanced) %>
             </div>
           </div>
           <p>Technologies: i.e. languages, frameworks etc.</p>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -10,6 +10,7 @@
     <p>Led by: <%= link_to @project.user.first_name, user_path(@project.user.id) %></p>  
   <% end %>
   <p class="project-description"><%= @project.description %></p>
+  <p class="project-description"><%= @project.rich_content %></p>
   <p>Estimated duration: <%= @project.duration %> days</p>
   <h5>Technologies involved</h5>
   <ul>

--- a/db/migrate/20200908215930_add_content_to_project.rb
+++ b/db/migrate/20200908215930_add_content_to_project.rb
@@ -1,0 +1,5 @@
+class AddContentToProject < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :rich_content, :text
+  end
+end

--- a/db/migrate/20200908221752_create_action_text_tables.action_text.rb
+++ b/db/migrate/20200908221752_create_action_text_tables.action_text.rb
@@ -1,0 +1,14 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :action_text_rich_texts do |t|
+      t.string     :name, null: false
+      t.text       :body, size: :long
+      t.references :record, null: false, polymorphic: true, index: false
+
+      t.timestamps
+
+      t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_01_193749) do
+ActiveRecord::Schema.define(version: 2020_09_08_215930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2020_09_01_193749) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "status", default: false
+    t.text "rich_content"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_08_215930) do
+ActiveRecord::Schema.define(version: 2020_09_08_221752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "body"
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/actioncable": "^6.0.0",
+    "@rails/actiontext": "^6.0.3-2",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "^5.2.1",
@@ -11,6 +12,7 @@
     "popper.js": "^1.16.1",
     "slick-carousel": "^1.8.1",
     "tiny-slider": "^2.9.3",
+    "trix": "^1.2.0",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/test/fixtures/action_text/rich_texts.yml
+++ b/test/fixtures/action_text/rich_texts.yml
@@ -1,0 +1,4 @@
+# one:
+#   record: name_of_fixture (ClassOfFixture)
+#   name: content
+#   body: <p>In a <i>million</i> stars!</p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,7 +895,14 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.0.3.tgz#722b4b639936129307ddbab3a390f6bcacf3e7bc"
   integrity sha512-I01hgqxxnOgOtJTGlq0ZsGJYiTEEiSGVEGQn3vimZSqEP1HqzyFNbzGTq14Xdyeow2yGJjygjoFF1pmtE+SQaw==
 
-"@rails/activestorage@^6.0.0":
+"@rails/actiontext@^6.0.3-2":
+  version "6.0.3-2"
+  resolved "https://registry.yarnpkg.com/@rails/actiontext/-/actiontext-6.0.3-2.tgz#19739f5c58fed879fedcd98039baf2be0bece52d"
+  integrity sha512-X7e7mDFeQZoTyPn+Dtu+dhwWfr/9I/h+pVhsAKCithCslcefuk5q4vmlfKWyIaKYNF5j821UdR3gfI8Nwr8Wjg==
+  dependencies:
+    "@rails/activestorage" "^6.0.0-alpha"
+
+"@rails/activestorage@^6.0.0", "@rails/activestorage@^6.0.0-alpha":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-6.0.3.tgz#401d2a28ecb7167cdb5e830ffddaa17c308c31aa"
   integrity sha512-YdNwyfryHlcKj7Ruix89wZ2aiN3KTYULdW1Y/hNlHJlrY2/PXjT2YBTzZiVd+dcjrwHBsXV2rExdy+Z/lsrlEg==
@@ -7130,6 +7137,11 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+
+trix@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/trix/-/trix-1.2.4.tgz#8b8f8ea58c2605ad3d04a3b82d60a994576e33a5"
+  integrity sha512-S6YUUaaHngNbW1jzBV3MQ35pisTV/x5yKlNZrAf8exkOnHsTj+2OJHx2jBLqRQEtpWHpg85pHjo2A7dKK2RQbQ==
 
 "true-case-path@^1.0.2":
   version "1.0.3"


### PR DESCRIPTION
Hey @kkoutoup @E-F-J  - PR as changes in some of the model and project pages, so to avoid conflicts.

i've added an extra column to projects (rich_content), and currently put into the project edit form (we may want as a seperate form once people are interested in a project. 

Cloudinary recently started blocking pdf retrieval unless requested and they authorise, but pictures/code/text formatting works. 

Also fixed the sign-up issue, and moved the user skill into the form