### PR TITLE
Adjust tech icons in homepage

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -16,8 +16,8 @@
   border-radius: 50%;
 }
 .avatar-bordered {
-  max-width: 72px;
-  max-height: 72px;
+  width: 72px;
+  height: 72px;
   border-radius: 50%;
   box-shadow: 0 1px 2px rgba(0,0,0,0.2);
   border: white 1px solid;

--- a/app/assets/stylesheets/components/_cards_homepage.scss
+++ b/app/assets/stylesheets/components/_cards_homepage.scss
@@ -66,6 +66,7 @@
     li:hover {
         cursor: pointer;
     }
+
 }
 
 .buddies {

--- a/app/assets/stylesheets/components/_cards_homepage.scss
+++ b/app/assets/stylesheets/components/_cards_homepage.scss
@@ -7,26 +7,42 @@
 .projects {
   width: 100%;
   display: grid !important;
-  // grid-template-rows: 1fr 1fr 2fr;
-  background: $white;
   padding: 15px;
-  margin: 8px 8px 8px 8px;
+  margin: 8px;
   height: 240px;
   overflow: hidden;
   color: white;
   background-image: url("https://image.freepik.com/free-vector/white-background-with-blue-tech-hexagon_1017-19366.jpg");
   font-size: 20px;
-  text-shadow: 1px 1px 1px 3px rgba(0,0,0,0.2);
+  // text-shadow: 1px 1px 1px 3px rgba(0,0,0,0.2);
   border-radius: 5px;
-  box-shadow: 0 0 10px rgba(0,0,0,0.2);
+  box-shadow: 2px 2px 5px rgba(0,0,0,0.1);
     a {
       color: $my-red;
     }
 }
 
+.fas {
+  color: $font-awesome-icons-gray;
+  opacity: 0.55;
+}
+
 .icon {
   // max-height: 50px;
   max-width: 30px;
+}
+
+.project-tech-icon-home {
+  // margin-top: 4px;
+  margin-right: 16px;
+  vertical-align: middle;
+  align-self: center;
+  width: 10%;
+  @media only screen and (max-width: 768px) {
+    & {
+      width: 5%;
+    }
+  }
 }
 
 .larger-text p {
@@ -83,14 +99,21 @@
   padding: 16px;
   background-color: $white;
   height: 240px;
-  display: grid;
   color: white;
   background-image: url("https://image.freepik.com/free-vector/white-background-with-blue-tech-hexagon_1017-19366.jpg");
-  font-size: 20px;
-  text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
   border-radius: 5px;
-  box-shadow: 0 0 15px rgba(0,0,0,0.2);
-  grid-template-columns: 2fr 2fr;
+  box-shadow: 2px 2px 5px rgba(0,0,0,0.1);
+}
+
+.buddies-list-top {
+  display: grid;
+  font-size: 20px;
+  grid-template-columns: 1fr 2fr;
+  height: 100px;
+}
+
+.buddies-list-bottom {
+  color: $medium-dark-gray;
 }
 
 

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -1,5 +1,4 @@
 .footer {
-    border-top: 1px solid $my-light-gray;
     background: #F4F4F4;
     display: flex;
     justify-content: center;

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -6,8 +6,7 @@ $blue: #167FFB;
 $yellow: #FFC65A;
 $orange: #E67E22;
 $green: #1EDD88;
-$gray: #0E0000;
-$light-gray: #F4F4F4;
+
 $white: #ffffff;
 
 // Custom colours:
@@ -25,3 +24,6 @@ $my-orange: #be7531;
 $my-pink: #F8EAEA;
 $my-light-green: #92bfa0;
 $navbar-gray: #f6f8fa;
+$font-awesome-icons-gray: #c0c0c0;
+$medium-dark-gray: #A9A9A9;
+$light-gray: #F4F4F4;

--- a/app/assets/stylesheets/projects/_project-index.scss
+++ b/app/assets/stylesheets/projects/_project-index.scss
@@ -1,7 +1,19 @@
 .introduction {
   p {
     font-size: 1rem;
+    font-weight: lighter;
   }
+  h5 {
+    color: $font-awesome-icons-gray;
+    font-weight: lighter;
+  }
+}
+
+#lighter-paragraph {
+  p {
+    font-weight: lighter;
+  }
+
 }
 
 .sticky-note {
@@ -25,7 +37,7 @@
 }
 
 .project-card {
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 2px 2px 5px rgba(0,0,0,0.1);
   border-radius: 5px;
   background-image: url(https://image.freepik.com/free-vector/white-background-with-blue-tech-hexagon_1017-19366.jpg);
   background-repeat: no-repeat;
@@ -46,6 +58,7 @@
   }
   p.project-level {
     font-size: .8rem;
+    color: #8c8c8c;
   }
   p.project-description {
     font-size: .9rem;
@@ -59,5 +72,7 @@
   &:hover {
     cursor: pointer;
     transform: scale(1.1);
+    transition: transform 0.2s ease-in-out;
+
   }
 }

--- a/app/assets/stylesheets/projects/_project-show.scss
+++ b/app/assets/stylesheets/projects/_project-show.scss
@@ -70,7 +70,7 @@ h1.project-title {
   display: inline-block;
   overflow: hidden;
   margin-right: 20px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 2px 2px 5px rgba(0,0,0,0.1);
   border-radius: 5px;
   background-image: url(https://image.freepik.com/free-vector/white-background-with-blue-tech-hexagon_1017-19366.jpg);
   background-repeat: no-repeat;
@@ -102,5 +102,6 @@ h1.project-title {
   &:hover {
     cursor: pointer;
     transform: scale(1.1);
+    transition: transform 0.2s ease-in-out;
   }
 }

--- a/app/assets/stylesheets/users/_users-show.scss
+++ b/app/assets/stylesheets/users/_users-show.scss
@@ -39,10 +39,10 @@
   margin-right: 16px;
   vertical-align: middle;
   align-self: center;
-  width: 20%;
+  width: 10%;
   @media only screen and (max-width: 768px) {
     & {
-      width: 15%;
+      width: 5%;
     }
   }
 }

--- a/app/assets/stylesheets/users/_users-show.scss
+++ b/app/assets/stylesheets/users/_users-show.scss
@@ -34,12 +34,25 @@
   background-repeat: no-repeat;
 }
 
+.user-tech-icon-home {
+  // margin-top: 4px;
+  margin-right: 16px;
+  vertical-align: middle;
+  align-self: center;
+  width: 20%;
+  @media only screen and (max-width: 768px) {
+    & {
+      width: 15%;
+    }
+  }
+}
+
 .user-tech-icon {
   // margin-top: 4px;
   margin-right: 16px;
   vertical-align: middle;
   align-self: center;
-  width: 5%;
+  width: 8%;
   @media only screen and (max-width: 768px) {
     & {
       width: 15%;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -70,9 +70,9 @@ document.addEventListener('turbolinks:load', () => {
               items: 3,
           }
       }
-
     });
   }
+
   const options = {
     show : true
   }

--- a/app/views/components/_homepage_banner.html.erb
+++ b/app/views/components/_homepage_banner.html.erb
@@ -2,8 +2,8 @@
   <div class="container">
     <div class="align-banner">
       <div class="banner-text">
-        <h1>The Community</h1>
-        <h3>Join the coding revolution. Clearly fake text</h3>
+        <h1>Find a coding buddy</h1>
+        <h3>Improve your tech skills and expand your network</h3>
       </div>  <!-- banner-text -->
     </div> <!-- align-banner -->
   </div>  <!-- container -->

--- a/app/views/components/_homepage_find_buddies.html.erb
+++ b/app/views/components/_homepage_find_buddies.html.erb
@@ -5,7 +5,7 @@
     </div>
 </div>
 
-<h3 class="sections-title">Find buddies to collaborate with:</h3>
+<h3 class="sections-title">Find buddies to collaborate with</h3>
 
 <div class="container">
 

--- a/app/views/components/_homepage_find_buddies.html.erb
+++ b/app/views/components/_homepage_find_buddies.html.erb
@@ -27,7 +27,7 @@
 
           <div>
             <% user.technologies.each do |technology| %>
-              <img src="<%= check_image_exists(technology) %>" alt="<%= technology.name %>-icon" class="user-tech-icon mt-5">
+              <img src="<%= check_image_exists(technology) %>" alt="<%= technology.name %>-icon" class="user-tech-icon-home mt-5">
             <% end %>
           </div>
         </div>

--- a/app/views/components/_homepage_find_buddies.html.erb
+++ b/app/views/components/_homepage_find_buddies.html.erb
@@ -11,23 +11,32 @@
 
   <div class="buddies">
       <% @users.each do |user| %>
+
         <div class="buddies-list">
-          <div class="avatar-bordered"
-            <% if user.photo.present? %>
-              style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path user.photo.key, :width=>72, :height=>72, :crop=>"fill" %>')">
+
+          <div class="buddies-list-top">
+            <div class="avatar-bordered"
+              <% if user.photo.present? %>
+                style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url('<%= cl_image_path user.photo.key, :width=>72, :height=>72, :crop=>"fill" %>')">
+              <% else %>
+                <%= image_tag "technologies_icons/logo-missing-img.png", :width=>72, :height=>72 %>
+              <% end %>
+            </div>
+
+            <div>
+              <p class="larger-text"><%= link_to user.first_name , user_path(user) %> </p>
+            </div>
+          </div>
+
+
+          <div class="buddies-list-bottom">
+            <% if user.technologies.present? %>
+              <% user.technologies.each do |technology| %>
+                <img src="<%= check_image_exists(technology) %>" alt="<%= technology.name %>-icon" class="user-tech-icon-home mt-5">
+              <% end %>
+
             <% else %>
-              <%= image_tag "technologies_icons/logo-missing-img.png", :width=>72, :height=>72 %>
-            <% end %>
-          </div>
-
-          <div>
-            <p class="larger-text"><%= link_to user.first_name , user_path(user) %> </p>
-            <p class="grey-text"> </p>
-          </div>
-
-          <div>
-            <% user.technologies.each do |technology| %>
-              <img src="<%= check_image_exists(technology) %>" alt="<%= technology.name %>-icon" class="user-tech-icon-home mt-5">
+              <p>You can see <%= user.first_name %>'s projects <%= link_to "here", user_path(user)  %></p>
             <% end %>
           </div>
         </div>

--- a/app/views/components/_homepage_how_it_works.html.erb
+++ b/app/views/components/_homepage_how_it_works.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <h3 class="sections-title">How it works:</h3>
+  <h3 class="sections-title">How it works</h3>
 
   <div class="main-how-it-works">
 

--- a/app/views/components/_homepage_latest_projects.html.erb
+++ b/app/views/components/_homepage_latest_projects.html.erb
@@ -5,7 +5,7 @@
     </div>
 </div>
 
-<h3 class="sections-title">Latest Projects:</h3>
+<h3 class="sections-title">Latest Projects</h3>
 
 <div class="container">
   <div class="slider-container">

--- a/app/views/components/_homepage_latest_projects.html.erb
+++ b/app/views/components/_homepage_latest_projects.html.erb
@@ -11,10 +11,10 @@
   <div class="slider-container">
       <ul class="controls" id="customize-controls" aria-label="Carousel Navigation" tabindex="0">
           <li class="prev" data-controls="prev" aria-controls="customize" tabindex="-1">
-              <i class="fas fa-angle-double-left fa-2x"></i>
+              <i class="fas fa-angle-left fa-2x"></i>
           </li>
           <li class="next" data-controls="next" aria-controls="customize" tabindex="-1">
-              <i class="fas fa-angle-double-right fa-2x"></i>
+              <i class="fas fa-angle-right fa-2x"></i>
           </li>
       </ul>
 
@@ -25,7 +25,7 @@
               <p class="project-side-header"><i class="fas fa-chart-bar"></i>  <%= project.difficulty.capitalize %></p>
             <div>
               <% project.technologies.each do |technology| %>
-                <img src="<%= check_image_exists(technology) %>" alt="<%= technology.name %>-icon" class="tech-icon mt-1">
+                <img src="<%= check_image_exists(technology) %>" alt="<%= technology.name %>-icon" class="project-tech-icon-home">
               <% end %>
             </div>
 

--- a/app/views/components/_project_search.html.erb
+++ b/app/views/components/_project_search.html.erb
@@ -1,4 +1,4 @@
-<h4 class="mt-5" id="search-header">Search</h4>
+<h5 class="mt-5">Search <i class="fas fa-search"></i></h5>
 <%= form_tag "projects#search-header", method: :get do %>
   <%= text_field_tag :query,
     params[:query],

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -19,7 +19,7 @@
       </div>
       <% if @projects.count > 0 %>
         <% if params[:query].present? %>
-          <p class="mt-5">We found <strong><%= pluralize(@projects.count, "project") %></strong> with <strong>"<%= params[:query] %>"</strong> in the title or description</p>
+          <p class="mt-5" id="lighter-paragraph">We found <strong><%= pluralize(@projects.count, "project") %></strong> with <strong>"<%= params[:query] %>"</strong> in the title or description</p>
         <% end %>
         <div class="row mt-5">
           <%= render 'components/project_loop' %>


### PR DESCRIPTION
hey guys, happy bunny here. I've done a lot of front end work which I'm pleased with. I now have to stop but don't worry I'll be back after work :)
so far:
**landing page:** carousel arrows changed, icons in cards resized, shadows on text gone and on cards resized and changed direction - hopefully that on all pages but I didn't check yet, I will do-, find buddies cards also restyled as per @kkoutoup suggestion (name closer to image) I will have to change a bit the project's cards to fix alignment there too. text weight changed in **project noticeboard** and added a search icon, I'm not sure if that looks better before or after the word "Search". transition on projects cards made slower.
Line at the top of the footer gone

next for me:
in /projects
(i.e)We found 2 projects with "java" in the title or description (i mean after we enter java in the search bar) to go lighter
in users/:id
too much to explain, but anyway I'd like to finish that so no need to bore you (the back button will go BTW as redundant/unnecessary as "back" is at the top left of any browser anyway. good as it was very temperamental).

@Vishal151 one of Dani's points about the user/:id page as it is now is that two cards there to hold half the info about the user each are weird, as that should be contained in one card. we have the same for the dashboard and as you were looking at that I thought I'd let you know so you might also style it with that in mind. also I've got the /user/:id conceptually wrong as lots of the wording in there belongs to the dashboard (in attached screenshot everything in the cards apart from the name and email address is personal dashboard text, not public user text, I had got that *very* wrong)

if too confusing I can take a quick call after 9.
x
e

I've failed with the favicon BTW. I know it's meant to be a very easy step but... it looks fuzzy and doesn't even pass the test! if anyone wants to do that I won't be offended :) 
![Screenshot 2020-09-21 at 07 20 44](https://user-images.githubusercontent.com/54990059/93737380-f8924800-fbda-11ea-8b1d-4ed1d8cc56ef.png)
